### PR TITLE
Allow type annotations to be discoverable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     name='iterable_collections',
     version='0.1.6',
     packages=['iterable_collections'],
+    package_data={'iterable_collections': ['*.pyi']},
     license='MIT License',
     author='Allie Fitter',
     author_email='fitterj@gmail.com',
@@ -16,15 +17,6 @@ setup(
     long_description_content_type='text/x-rst',
     keywords=['collection', 'map', 'filter', 'pipeline', 'linq', 'scala'],
     url='https://github.com/alliefitter/iterable_collections',
-    data_files=[(
-        'lib/python{}.{}/site-packages/iterable_collections'.format(*sys.version_info[:2]),
-        [
-            "iterable_collections/collection.pyi",
-            "iterable_collections/strategy.pyi",
-            "iterable_collections/factory.pyi",
-            "iterable_collections/utils.pyi"
-        ]
-    )],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='iterable_collections',
     version='0.1.6',
     packages=['iterable_collections'],
-    package_data={'iterable_collections': ['*.pyi']},
+    package_data={'iterable_collections': ['py.typed', '*.pyi']},
     license='MIT License',
     author='Allie Fitter',
     author_email='fitterj@gmail.com',


### PR DESCRIPTION
Existing implementation installed pyi using build python version for destination paths.  This could be different from the install time python version.

Also type checkers (at least mypy) want a py.typed file at the root of the package before they will look for typing information.